### PR TITLE
CSSIR-8817 prevent doubling data in ELD

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -30,4 +30,5 @@ window.panelCreated = function appInit(devtools) {
     }
     root.render(<App onRequestFinished={devtools.network.onRequestFinished} initialRequests={initialRequests} />);
   });
+  initialRequests.length = 0;
 };


### PR DESCRIPTION
This is a continuation of a previous PR. As a result of last changes values in ELD were doubled each time user clicked on the icon again. Right now values were not be doubled, but the ELD will have to be refreshed manually each time har file is imported to the browser. I'm still searching for better approach, but for now this works and will prevent the bug. 